### PR TITLE
add filter documentation

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,5 +1,7 @@
 module.exports = {
     initialize: function(options) {
+        //XXX The latest stable release v2.1 does not support complex filter expressions:
+        //  http://opentsdb.net/docs/build/html/user_guide/query/filters.html
         this.error = options.error('RT-TYPE-ERROR', {
             message: "Only AND and '=' operators with string values are supported in the optimized filter expression."
         });


### PR DESCRIPTION
Tried looking at filter possibilities more closely and found that the latest stable release doesn't allow for complex filtering. Just `AND` and `=` operations.

v2.2 will allow for more complex stuff: http://opentsdb.net/docs/build/html/user_guide/query/filters.html

One question I was wondering about:
Suppose an adapter's filter system doesn't support all that juttle's filter logic offers. Shouldn't the filter before the first `|` follow the conditional optimization strategy currently executed by `head` or `reduce` for ES or SQL? In other words shouldn't the adapter be able to conditionally offload filtering to juttle instead of using internal db logic?
