### PR TITLE
Require FilterJSCompiler directly

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var db = require('./db');
 var Filter = require('./filter');
+var FilterJSCompiler = require('juttle/lib/compiler/filters/filter-js-compiler');
 var Juttle = require('juttle/lib/runtime').Juttle;
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var Promise = require('bluebird');
@@ -59,7 +60,7 @@ var Read = Juttle.proc.source.extend({
     },
 
     addFilters: function(filter_ast) {
-        var FilterCompiler = Juttle.FilterJSCompiler.extend(Filter);
+        var FilterCompiler = FilterJSCompiler.extend(Filter);
         var compiler = new FilterCompiler({
             query: this.query,
             error: this.compile_error.bind(this)


### PR DESCRIPTION
Instead of using `Juttle.FilterJSCompiler` to access `FilterJSCompiler`, require it directly. The `Juttle.FilterJSCompiler` property will cease to be available soon.

Part of work on juttle/juttle#97.