### PR TITLE
use absolute time, requiredOptions and eof

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -17,6 +17,10 @@ class ReadOpenTSDB extends AdapterRead {
         return AdapterRead.commonOptions().concat(['name', 'debug', 'id']);
     }
 
+    static requiredOptions() {
+        return ['from'];
+    }
+    
     //initialization functions
 
     constructor(options, params) {
@@ -25,7 +29,6 @@ class ReadOpenTSDB extends AdapterRead {
         this.logger.debug('init proc name:', this.procName);
         this.logger.debug('options:', options);
 
-        this.validateOptions(options);
         this.setOptions(options);
 
         this.client = db.getClient(options.id);
@@ -38,12 +41,6 @@ class ReadOpenTSDB extends AdapterRead {
 
     periodicLiveRead() {
         return true;
-    }
-
-    validateOptions(options) {
-        if (!_.has(options, 'from')) {
-            throw this.compileError('MISSING-OPTION', { option: "from" });
-        }
     }
 
     setOptions(options) {
@@ -102,13 +99,19 @@ class ReadOpenTSDB extends AdapterRead {
 
     addTimeLimitsToClient(from, to) {
         if (from) {
-            this.client.start(from.milliseconds());
-            this.logger.debug('start time', JSON.stringify(from));
+            let start = this.getAbsoluteTime(from.clone());
+            this.client.start(start);
+            this.logger.debug('start time', start);
         }
-
-        let end = to || new Date();
-        this.client.end(end.milliseconds());
-        this.logger.debug('end time', JSON.stringify(end));
+        
+        let end = to || new JuttleMoment({rawDate: new Date()});
+        end = this.getAbsoluteTime(end.clone());
+        this.client.end(end);
+        this.logger.debug('end time', end);
+    }
+    
+    getAbsoluteTime(juttleMoment) {
+        return JuttleMoment.format(juttleMoment, 'YYYY/MM/DD-HH:mm:ss');
     }
 
     formatPoints(metric_info) {
@@ -133,7 +136,7 @@ class ReadOpenTSDB extends AdapterRead {
             points: [{
                 url: this.client.url()
             }],
-            readEnd: new JuttleMoment(Infinity)
+            eof: true
         };
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,9 @@
   "dependencies": {
     "bluebird": "^3.0.5",
     "bluebird-retry": "^0.5.3",
-    "opentsdb": "juttle/opentsdb.js#temp-client",
+    "opentsdb": "^0.5.7",
     "opentsdb-socket": "0.0.2",
-    "underscore": "^1.8.3",
-    "opentsdb-client": "juttle/client#allow-unix-time-zero",
-    "opentsdb-datum": "juttle/datum#allow-value-zero",
-    "opentsdb-validate-time": "juttle/validate-time#unix-time-before-2001"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
1. Use absolute time instead to unix time to allow `-from :0:` and avoid confusion between seconds and milliseconds. The absolute time format: `yyyy/MM/dd-HH:mm:ss`. This is the bugfix PR on the driver that made this possible: https://github.com/opentsdb-js/url/pull/1
2. Use `eof` key when returning promise from read method.
3. The opentsdb.js maintainer also updated the versions of `datum` and `url` in the main opentsdb.js repo after merging my changes so I removed all the references to our forks. Yey!

fixes https://github.com/juttle/juttle-opentsdb-adapter/issues/25 also